### PR TITLE
Added the IJsonPatchPropertyResolver and default class

### DIFF
--- a/src/Nancy.JsonPatch.Tests/Nancy.JsonPatch.Tests.csproj
+++ b/src/Nancy.JsonPatch.Tests/Nancy.JsonPatch.Tests.csproj
@@ -82,6 +82,7 @@
     <Compile Include="PathParser\JsonPatchPathParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="DocumentParser\JsonPatchDocumentParserTests.cs" />
+    <Compile Include="PropertyResolver\JsonPatchPropertyResolverTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Nancy.JsonPatch.Tests/PathParser/JsonPatchPathParserTests.cs
+++ b/src/Nancy.JsonPatch.Tests/PathParser/JsonPatchPathParserTests.cs
@@ -4,6 +4,7 @@ namespace Nancy.JsonPatch.Tests.PathParser
     using System.Collections.Generic;
     using Fakes;
     using JsonPatch.PathParser;
+    using PropertyResolver;
     using Should;
     using Xunit;
 
@@ -13,7 +14,7 @@ namespace Nancy.JsonPatch.Tests.PathParser
 
         public JsonPatchPathParserTests()
         {
-            _pathParser = new JsonPatchPathParser();
+            _pathParser = new JsonPatchPathParser(new JsonPatchPropertyResolver());
         }
 
         [Fact]

--- a/src/Nancy.JsonPatch.Tests/PathParser/JsonPatchPathParserTests.cs
+++ b/src/Nancy.JsonPatch.Tests/PathParser/JsonPatchPathParserTests.cs
@@ -4,7 +4,7 @@ namespace Nancy.JsonPatch.Tests.PathParser
     using System.Collections.Generic;
     using Fakes;
     using JsonPatch.PathParser;
-    using PropertyResolver;
+    using JsonPatch.PropertyResolver;
     using Should;
     using Xunit;
 

--- a/src/Nancy.JsonPatch.Tests/PropertyResolver/JsonPatchPropertyResolverTests.cs
+++ b/src/Nancy.JsonPatch.Tests/PropertyResolver/JsonPatchPropertyResolverTests.cs
@@ -1,0 +1,27 @@
+﻿using Nancy.JsonPatch.PropertyResolver;
+
+namespace Nancy.JsonPatch.Tests.PropertyResolver
+{
+    using Should;
+    using Xunit;
+
+    public class JsonPatchPropertyResolverTests
+    {
+        private readonly IJsonPatchPropertyResolver _propertyResolver;
+
+        public JsonPatchPropertyResolverTests()
+        {
+            _propertyResolver = new JsonPatchPropertyResolver();
+        }
+
+        [Fact]
+        public void Returns_Parameter()
+        {
+            const string propertyName = "TestProperty";
+
+            var result = _propertyResolver.Resolve(null, propertyName);
+
+            result.ShouldBeSameAs(propertyName);
+        }
+    }
+}

--- a/src/Nancy.JsonPatch/JsonPatchExecutor.cs
+++ b/src/Nancy.JsonPatch/JsonPatchExecutor.cs
@@ -3,13 +3,19 @@
     using System;
     using System.Collections.Generic;
     using Models;
+    using PropertyResolver;
     
     internal class JsonPatchExecutor
     {
         public JsonPatchResult Patch<T>(string requestBody, T target)
         {
+            return Patch(requestBody, target, new JsonPatchPropertyResolver());
+        }
+
+        public JsonPatchResult Patch<T>(string requestBody, T target, IJsonPatchPropertyResolver propertyResolver)
+        {
             var documentParser = new DocumentParser.JsonPatchDocumentParser();
-            var pathParser = new PathParser.JsonPatchPathParser();
+            var pathParser = new PathParser.JsonPatchPathParser(propertyResolver);
             var operationExecutor = new OperationProcessor.JsonPatchOperationExecutor();
             
             List<JsonPatchOperation> operations;

--- a/src/Nancy.JsonPatch/JsonPatchModuleExtensions.cs
+++ b/src/Nancy.JsonPatch/JsonPatchModuleExtensions.cs
@@ -1,12 +1,19 @@
 ﻿namespace Nancy.JsonPatch
 {
     using Extensions;
+    using PropertyResolver;
 
     public static class JsonPatchModuleExtensions
     {
         public static JsonPatchResult JsonPatch<T>(this NancyModule module, T target)
         {
-            return new JsonPatchExecutor().Patch(module.Request.Body.AsString(),target);
+            return JsonPatch(module, target, new JsonPatchPropertyResolver());
+        }
+
+        public static JsonPatchResult JsonPatch<T>(this NancyModule module, T target,
+            IJsonPatchPropertyResolver propertyResolver)
+        {
+            return new JsonPatchExecutor().Patch(module.Request.Body.AsString(), target, propertyResolver);
         }
     }
 }

--- a/src/Nancy.JsonPatch/Nancy.JsonPatch.csproj
+++ b/src/Nancy.JsonPatch/Nancy.JsonPatch.csproj
@@ -58,6 +58,8 @@
     <Compile Include="DocumentParser\JsonPatchRequestConverter.cs" />
     <Compile Include="PathParser\JsonPatchPathParserResult.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="PropertyResolver\IJsonPatchPropertyResolver.cs" />
+    <Compile Include="PropertyResolver\JsonPatchPropertyResolver.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Nancy.JsonPatch/PropertyResolver/IJsonPatchPropertyResolver.cs
+++ b/src/Nancy.JsonPatch/PropertyResolver/IJsonPatchPropertyResolver.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Nancy.JsonPatch.PropertyResolver
+{
+    public interface IJsonPatchPropertyResolver
+    {
+        string Resolve(Type type, string propertyName);
+    }
+}

--- a/src/Nancy.JsonPatch/PropertyResolver/JsonPatchPropertyResolver.cs
+++ b/src/Nancy.JsonPatch/PropertyResolver/JsonPatchPropertyResolver.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Nancy.JsonPatch.PropertyResolver
+{
+    public class JsonPatchPropertyResolver : IJsonPatchPropertyResolver
+    {
+        public string Resolve(Type type, string propertyName)
+        {
+            return propertyName;
+        }
+    }
+}


### PR DESCRIPTION
This way we can handle a scenario where the property names on the request object are not the same as the ones on the actual object, such as in the case of when you are using a `ContractResolver`.

Fixes issue #1 
